### PR TITLE
Support certbot 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 acme>=0.22
-certbot>=0.22
+certbot>=1.0.0
 PyOpenSSL
 setuptools
 zope.component

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires=[
         'acme>=0.22.0',
-        'certbot>=0.22.0',
+        'certbot>=1.0.0',
         'PyOpenSSL',
         'setuptools',
         'zope.component',

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -9,10 +9,8 @@ from certbot_redis.plugin import Authenticator
 import fakeredis
 import mock
 
-from certbot import achallenges, configuration
-
-from certbot import constants
-
+from certbot import achallenges
+from certbot._internal import configuration, constants
 from certbot.tests import acme_util
 
 


### PR DESCRIPTION
Certbot 1.0.0 was released recently, requiring changes to the test imports.