### PR TITLE
Add an option to add a prefix to the Redis key

### DIFF
--- a/certbot_redis/plugin.py
+++ b/certbot_redis/plugin.py
@@ -19,12 +19,15 @@ class Authenticator(common.Plugin):
     @classmethod
     def add_parser_arguments(cls, add):
         add("redis-url", default=os.getenv('REDIS_URL'),
-            help="redis-url url of the redis insteance you want to store your challenges in")
+            help="redis-url url of the redis instance you want to store your challenges in")
+        add("redis-prefix", default='',
+            help="prefix to prepend to the challenge key")
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
         self._httpd = None
         self.redis_client = StrictRedis.from_url(self.conf('redis-url'), socket_keepalive=True)
+        self.redis_prefix = self.conf('redis-prefix') if self.conf('redis-prefix') else ''
 
     def prepare(self):  # pylint: disable=missing-docstring,no-self-use
         pass  # pragma: no cover
@@ -38,7 +41,7 @@ class Authenticator(common.Plugin):
 
     def _get_key(self, achall):   # pylint: disable=missing-docstring
         key = achall.chall.path[1:].split("/")[2]
-        return str(key)
+        return self.redis_prefix + str(key)
 
     def perform(self, achalls):  # pylint: disable=missing-docstring
         responses = []

--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,4 @@ Installation guide:
  ``` certbot certonly -a certbot-redis:redis --certbot-redis:redis-redis-url=your_redis_server:port```
 
 * Keep in mind, that you'll need a webapplication, that reads the challenge from redis, and responds to it at .well-known/acme-challenge/{key}
+* Use `--certbot-redis:redis-redis-prefix=secretPrefix:` to prefix the Redis key with `secretPrefix:`.


### PR DESCRIPTION
This adds an optional flag, `--certbot-redis:redis-redis-prefix`, which can be used to prepend a prefix to the Redis key.

Without a prefix, the web service can be used to retrieve any key from the database. With a prefix, only keys starting with the prefix can be retrieved.